### PR TITLE
Added note about using python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ This is the core web crawler that will be used for the human trafficking project
   # build
   cd palantiri
   
-  # install pip; anaconda python package is easiest way to do this https://www.continuum.io/downloads
+  # Make sure you are using python3, then use pip to install dependencies
+  # The anaconda package and version manager is easiest way to do this https://www.continuum.io/downloads
   pip install -e .
 
   # test


### PR DESCRIPTION
The C compiler will throw an error when it tries to build the extensions in `src/ext/util.c` if it's using the python 2.7 dev headers. Given that some users will be using python 2.x by default, I think it's important to explain in the README that the project works only with python3. Working on cross-version compatibility can be a job we tackle later.

To this end I've added a couple lines to the README explaining that python3 is necessary for installation.